### PR TITLE
just use "batctl meshif" instead of "batctl -m"

### DIFF
--- a/lib/neighbours.py
+++ b/lib/neighbours.py
@@ -33,7 +33,7 @@ class Neighbours(Respondd):
   def getMeshInterfaces(batmanInterface):
     ret = {}
 
-    lines = lib.helper.call(['batctl', '-m', batmanInterface, 'if'])
+    lines = lib.helper.call(['batctl', 'meshif', batmanInterface, 'if'])
     for line in lines:
       lineMatch = re.match(r'^([^:]*)', line)
       interface = lineMatch.group(1)
@@ -52,7 +52,7 @@ class Neighbours(Respondd):
 
     meshInterfaces = self.getMeshInterfaces(self._config['batman'])
 
-    lines = lib.helper.call(['batctl', '-m', self._config['batman'], 'o', '-n'])
+    lines = lib.helper.call(['batctl', 'meshif', self._config['batman'], 'o', '-n'])
     for line in lines:
       # * e2:ad:db:b7:66:63    2.712s   (175) be:b7:25:4f:8f:96 [mesh-vpn-l2tp-1]
       lineMatch = re.match(r'^[ \*\t]*([0-9a-f:]+)[ ]*([\d\.]*)s[ ]*\(([ ]*\d*)\)[ ]*([0-9a-f:]+)[ ]*\[[ ]*(.*)\]', line, re.I)

--- a/lib/nodeinfo.py
+++ b/lib/nodeinfo.py
@@ -30,7 +30,7 @@ class Nodeinfo(Respondd):
   def getBatmanInterfaces(self, batmanInterface):
     ret = {}
 
-    lines = lib.helper.call(['batctl', '-m', batmanInterface, 'if'])
+    lines = lib.helper.call(['batctl', 'meshif', batmanInterface, 'if'])
     for line in lines:
       lineMatch = re.match(r'^([^:]*)', line)
       interface = lineMatch.group(0)
@@ -77,7 +77,7 @@ class Nodeinfo(Respondd):
 
   @staticmethod
   def getVPNFlag(batmanInterface):
-    lines = lib.helper.call(['batctl', '-m', batmanInterface, 'gw_mode'])
+    lines = lib.helper.call(['batctl', 'meshif', batmanInterface, 'gw_mode'])
     if re.match(r'^server', lines[0]):
       return True
     else:

--- a/lib/respondd_client.py
+++ b/lib/respondd_client.py
@@ -42,7 +42,7 @@ class ResponddClient:
     self._sock.setsockopt(socket.SOL_SOCKET,socket.SO_BINDTODEVICE,bytes(self._config['bridge'].encode()))
     self._sock.bind(('::', self._config['port']))
 
-    lines = lib.helper.call(['batctl', '-m', self._config['batman'], 'if'])
+    lines = lib.helper.call(['batctl', 'meshif', self._config['batman'], 'if'])
     for line in lines:
       lineMatch = re.match(r'^([^:]*)', line)
       self.joinMCAST(self._sock, self._config['addr'], lineMatch.group(1))

--- a/lib/statistics.py
+++ b/lib/statistics.py
@@ -19,7 +19,7 @@ class Statistics(Respondd):
 
     macBridge = lib.helper.getInterfaceMAC(self._config['bridge'])
 
-    lines = lib.helper.call(['batctl', '-m', self._config['batman'], 'tl', '-n'])
+    lines = lib.helper.call(['batctl', 'meshif', self._config['batman'], 'tl', '-n'])
     for line in lines:
       # batman-adv -> translation-table.c -> batadv_tt_local_seq_print_text
       # R = BATADV_TT_CLIENT_ROAM
@@ -139,7 +139,7 @@ class Statistics(Respondd):
   def getGateway(self):
     ret = None
 
-    lines = lib.helper.call(['batctl', '-m', self._config['batman'], 'gwl', '-n'])
+    lines = lib.helper.call(['batctl', 'meshif', self._config['batman'], 'gwl', '-n'])
     for line in lines:
       lineMatch = re.match(r'(\*|=>)\s+([0-9a-f:]+)\s\([\d \.]+\)\s+([0-9a-f:]+)', line)
       if lineMatch:


### PR DESCRIPTION
"batctl -m ..." throws an error/deprecation warning. asking for a certain interface is done by "batctl meshif ..." now